### PR TITLE
Fix completely broken Menu component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- fix completely broken Menu component ([#2](https://github.com/seaofvoices/react-roblox-studio-plugin/pull/2))
 - fix toolbar and toolbar button components to avoid creating them twice ([#1](https://github.com/seaofvoices/react-roblox-studio-plugin/pull/1))
 
 ## 0.1.0

--- a/src/Widget.lua
+++ b/src/Widget.lua
@@ -84,9 +84,7 @@ local function Widget(props: Props)
     end, { dockWidget or false, title } :: { any })
 
     React.useEffect(function()
-        -- print('enabled changed:', enabled)
         if dockWidget ~= nil and dockWidget.Enabled ~= enabled then
-            -- print("define enabled!")
             dockWidget.Enabled = enabled
         end
     end, { dockWidget or false, enabled } :: { any })


### PR DESCRIPTION
The Menu component was not rendering its associated context provider and its children, which made it impossible to use the actions inside Menus.

- [x] add entry to the changelog
